### PR TITLE
Fix/self collision behaviour

### DIFF
--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include <controller_interface/controller_base.h>
 #include <controller_interface/multi_interface_controller.h>
 #include <dynamic_reconfigure/server.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -218,7 +219,7 @@ class BiManualCartesianImpedanceControl
   double joint_limits[7][2];
   double calculateTauJointLimit(double q_value, double threshold, double magnitude, double upper_bound, double lower_bound);
 
-  ControllerState controller_state_{NORMAL_OPERATION};
+  ControllerState controller_state_{controller_interface::ControllerBase::ControllerState::RUNNING};
   franka::RobotMode prev_robot_mode_left_{franka::RobotMode::kOther};
   franka::RobotMode prev_robot_mode_right_{franka::RobotMode::kOther};
 

--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -29,12 +29,6 @@
 
 namespace franka_bimanual_controllers {
 
-// State machine
-enum ControllerState {
-  NORMAL_OPERATION,
-  COLLISION_DETECTED,
-  RECOVERY_PENDING
-};
 
 /**
  * This container holds all data and parameters used to control one panda arm with a Cartesian

--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -220,7 +220,7 @@ class BiManualCartesianImpedanceControl
   double joint_limits[7][2];
   double calculateTauJointLimit(double q_value, double threshold, double magnitude, double upper_bound, double lower_bound);
 
-  controller_interface::ControllerBase::ControllerState  controller_state_{controller_interface::ControllerBase::ControllerState::RUNNING};
+  controller_interface::ControllerBase::ControllerState  controller_state_{controller_interface::ControllerBase::ControllerState::STOPPED};
   franka::RobotMode prev_robot_mode_left_{franka::RobotMode::kOther};
   franka::RobotMode prev_robot_mode_right_{franka::RobotMode::kOther};
 

--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -104,7 +104,8 @@ class BiManualCartesianImpedanceControl
  private:
   // Publisher for automatic error recovery
   ros::Publisher pub_error_recovery_;
-
+  bool left_needs_recovery_ = false;
+  bool right_needs_recovery_ = false;
   std::map<std::string, FrankaDataContainer>
       arms_data_;             ///< Holds all relevant data for both arms.
   std::string left_arm_id_;   ///< Name of the left arm, retrieved from the parameter server.

--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -100,6 +100,13 @@ class BiManualCartesianImpedanceControl
   void update(const ros::Time&, const ros::Duration& period) override;
 
  private:
+  // Publisher for automatic error recovery
+  ros::Publisher pub_error_recovery_;
+
+  // Flags to track if arms are in an error state
+  bool left_arm_in_error_{false};
+  bool right_arm_in_error_{false};
+
   std::map<std::string, FrankaDataContainer>
       arms_data_;             ///< Holds all relevant data for both arms.
   std::string left_arm_id_;   ///< Name of the left arm, retrieved from the parameter server.

--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -218,6 +218,9 @@ class BiManualCartesianImpedanceControl
   ros::Publisher pub_force_torque_right;
   ros::Publisher pub_force_torque_left;
 
+  ros::Publisher pub_robot_mode_left_;
+  ros::Publisher pub_robot_mode_right_;
+
   double joint_limits[7][2];
   double calculateTauJointLimit(double q_value, double threshold, double magnitude, double upper_bound, double lower_bound);
 

--- a/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
+++ b/include/franka_bimanual_controllers/bimanual_cartesian_impedance_controller.h
@@ -219,7 +219,7 @@ class BiManualCartesianImpedanceControl
   double joint_limits[7][2];
   double calculateTauJointLimit(double q_value, double threshold, double magnitude, double upper_bound, double lower_bound);
 
-  ControllerState controller_state_{controller_interface::ControllerBase::ControllerState::RUNNING};
+  controller_interface::ControllerBase::ControllerState  controller_state_{controller_interface::ControllerBase::ControllerState::RUNNING};
   franka::RobotMode prev_robot_mode_left_{franka::RobotMode::kOther};
   franka::RobotMode prev_robot_mode_right_{franka::RobotMode::kOther};
 

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -12,6 +12,7 @@
 #include <franka_bimanual_controllers/pseudo_inversion.h>
 #include <franka_bimanual_controllers/franka_model.h>
 #include <franka_hw/trigger_rate.h>
+#include <franka_msgs/ErrorRecoveryActionGoal.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
@@ -491,7 +492,7 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   franka::RobotState robot_state_right = right_arm_data.state_handle_->getRobotState();
 
   //JUST FOR DEBUGGING
-  ROS_INFO_THROTTLE(1.0, "Current left arm mode: %d", static_cast<int>(robot_state_left.robot_mode));
+  ROS_INFO_THROTTLE(1.0, "Current right arm mode: %d", static_cast<int>(robot_state_right.robot_mode));
 
   if (robot_state_right.robot_mode == franka::RobotMode::kIdle) {
     if (!right_arm_in_error_) {

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -200,21 +200,22 @@ bool BiManualCartesianImpedanceControl::init(hardware_interface::RobotHW* robot_
    // Subscribe to heartbeat topic
    heartbeat_sub_ = node_handle.subscribe(
        "collision_detection_heartbeat", 1, &BiManualCartesianImpedanceControl::heartbeatCallback, this);
+  // store initial state
+  franka::RobotState initial_state_left = arms_data_.at(left_arm_id_).state_handle_->getRobotState();
+  prev_robot_mode_left_ = initial_state_left.robot_mode;
 
-   return left_success && right_success;
+  franka::RobotState initial_state_right = arms_data_.at(right_arm_id_).state_handle_->getRobotState();
+  prev_robot_mode_right_ = initial_state_right.robot_mode;
+  
+  // initialize controller state
+  controller_state_ = controller_interface::ControllerBase::ControllerState::RUNNING;
+
+  return left_success && right_success;
 }
 
 void BiManualCartesianImpedanceControl::starting(const ros::Time& time) {
 startingArmLeft();
 startingArmRight();
-
-franka::RobotState initial_state_left = arms_data_.at(left_arm_id_).state_handle_->getRobotState();
-prev_robot_mode_left_ = initial_state_left.robot_mode;
-
-franka::RobotState initial_state_right = arms_data_.at(right_arm_id_).state_handle_->getRobotState();
-prev_robot_mode_right_ = initial_state_right.robot_mode;
-
-controller_state_ = controller_interface::ControllerBase::ControllerState::RUNNING;
 
 {
  std::lock_guard<std::mutex> lock(heartbeat_mutex_);

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -24,7 +24,7 @@
 namespace franka_bimanual_controllers {
 
 template <typename Derived>
-void clipVectorMagnitude(Eigen::Ref<Derived> vec, const double limit) {
+void clipVectorMagnitude(Eigen::MatrixBase<Derived>& vec, const double limit) {
     const double magnitude = vec.norm();
     // Only scale the vector if its magnitude is non-zero and exceeds the limit.
     if (magnitude > limit && magnitude > 0) {
@@ -597,7 +597,7 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   // define orientation error clipping limit
   const double orientation_delta_lim = delta_lim * 3.0;
   // clip the orientation error
-  clipVectorMagnitude(error_right.tail(3), orientation_delta_lim);
+  clipVectorMagnitude(error_right.tail(3), orientation_delta_lim)
   
 
   // compute control

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -182,7 +182,7 @@ bool BiManualCartesianImpedanceControl::init(hardware_interface::RobotHW* robot_
           std::string param_name = "/joint" + std::to_string(i + 1) + "/limit/" + limit_type;
           if (!node_handle.getParam(param_name, joint_limits[i][limit_type == "lower" ? 0 : 1])) {
               ROS_ERROR("Failed to retrieve parameter: %s", param_name.c_str());
-              return 1;
+              return false;
           }
       }
   }
@@ -340,8 +340,6 @@ void BiManualCartesianImpedanceControl::startingArmLeft() {
   // set target point to current state
   left_arm_data.position_d_ = initial_transform.translation();
   left_arm_data.orientation_d_ = Eigen::Quaterniond(initial_transform.linear());
-  left_arm_data.position_d_ = initial_transform.translation();
-  left_arm_data.orientation_d_ = Eigen::Quaterniond(initial_transform.linear());
 
   // set nullspace target configuration to initial q
   left_arm_data.q_d_nullspace_ = q_initial;
@@ -363,8 +361,6 @@ void BiManualCartesianImpedanceControl::startingArmRight() {
   Eigen::Affine3d initial_transform(Eigen::Matrix4d::Map(initial_state.O_T_EE.data()));
 
   // set target point to current state
-  right_arm_data.position_d_ = initial_transform.translation();
-  right_arm_data.orientation_d_ = Eigen::Quaterniond(initial_transform.linear());
   right_arm_data.position_d_ = initial_transform.translation();
   right_arm_data.orientation_d_ = Eigen::Quaterniond(initial_transform.linear());
 

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -158,6 +158,9 @@ bool BiManualCartesianImpedanceControl::init(hardware_interface::RobotHW* robot_
   pub_force_torque_right= node_handle.advertise<geometry_msgs::WrenchStamped>("/force_torque_right_ext",1);
   pub_force_torque_left= node_handle.advertise<geometry_msgs::WrenchStamped>("/force_torque_left_ext",1);
 
+  pub_robot_mode_left_ = node_handle.advertise<std_msgs::Int32>("panda_left_robot_mode", 1);
+  pub_robot_mode_right_ = node_handle.advertise<std_msgs::Int32>("panda_right_robot_mode", 1);
+
   pub_error_recovery_ = node_handle.advertise<franka_msgs::ErrorRecoveryActionGoal>("/panda_dual/error_recovery/goal", 1, true);
 
   dynamic_reconfigure_compliance_param_node_ =
@@ -257,6 +260,14 @@ void BiManualCartesianImpedanceControl::update(const ros::Time& time,
   // Get current robot states
   franka::RobotState robot_state_left = arms_data_.at(left_arm_id_).state_handle_->getRobotState();
   franka::RobotState robot_state_right = arms_data_.at(right_arm_id_).state_handle_->getRobotState();
+
+  std_msgs::Int32 left_mode_msg;
+  left_mode_msg.data = static_cast<int>(robot_state_left.robot_mode);
+  pub_robot_mode_left_.publish(left_mode_msg);
+
+  std_msgs::Int32 right_mode_msg;
+  right_mode_msg.data = static_cast<int>(robot_state_right.robot_mode);
+  pub_robot_mode_right_.publish(right_mode_msg);
 
   // e-stop recovery check
   bool left_needs_recovery = (prev_robot_mode_left_ == franka::RobotMode::kUserStopped && robot_state_left.robot_mode == franka::RobotMode::kIdle);

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -23,15 +23,6 @@
 #include <std_srvs/SetBool.h>
 namespace franka_bimanual_controllers {
 
-template <typename Derived>
-void clipVectorMagnitude(Eigen::MatrixBase<Derived>& vec, const double limit) {
-    const double magnitude = vec.norm();
-    // Only scale the vector if its magnitude is non-zero and exceeds the limit.
-    if (magnitude > limit && magnitude > 0) {
-        vec *= (limit / magnitude);
-    }
-}
-
 bool BiManualCartesianImpedanceControl::initArm(
     hardware_interface::RobotHW* robot_hw,
     const std::string& arm_id,
@@ -349,7 +340,9 @@ void BiManualCartesianImpedanceControl::updateArmLeft() {
   Eigen::Affine3d transform_right(Eigen::Matrix4d::Map(robot_state_right.O_T_EE.data()));
   Eigen::Map<Eigen::Matrix<double, 7, 1>> dq_right(robot_state_right.dq.data());
   Eigen::Vector3d position_right(transform_right.translation());
-
+  // left_arm_data.position_other_arm_=position_right;
+  // compute error to desired pose
+  // position error
   geometry_msgs::PoseStamped msg_left;
   msg_left.pose.position.x=position[0];
   msg_left.pose.position.y=position[1];
@@ -385,21 +378,27 @@ void BiManualCartesianImpedanceControl::updateArmLeft() {
   force_torque_msg.wrench.torque.z=left_arm_data.force_torque[5];
   pub_force_torque_left.publish(force_torque_msg);
 
-  // compute error to desired pose
-  // position error
   Eigen::Matrix<double, 6, 1> error_left;
   error_left.head(3) << position - left_arm_data.position_d_;
-  // clip the position error
-  clipVectorMagnitude(error_left.head(3), delta_lim);
 
+  // calculate the magnitude of the position error
+  double position_error_magnitude = error_left.head(3).norm();
+  if (position_error_magnitude > delta_lim){
+    // scale the position error to the delta_lim
+    error_left.head(3) *= (delta_lim / position_error_magnitude);
+  }
 
-  // relative position error
   Eigen::Matrix<double, 6, 1> error_relative;
   error_relative.head(3) << position - position_right;
   error_relative.tail(3).setZero();
   error_relative.head(3)<< error_relative.head(3) -left_arm_data.position_d_relative_;
-  // clip the relative position error
-  clipVectorMagnitude(error_relative.head(3), delta_lim);
+
+  // calculate the magnitude of the relative position error
+  double relative_error_magnitude = error_relative.head(3).norm();
+  if (relative_error_magnitude > delta_lim){
+    // scale the relative position error to the delta_lim
+    error_relative.head(3) *= (delta_lim / relative_error_magnitude);
+  }
 
   // orientation error
   if (left_arm_data.orientation_d_.coeffs().dot(orientation.coeffs()) < 0.0) {
@@ -411,10 +410,16 @@ void BiManualCartesianImpedanceControl::updateArmLeft() {
   Eigen::AngleAxisd error_quaternion_angle_axis(error_quaternion);
   // compute "orientation error"
   error_left.tail(3) << error_quaternion_angle_axis.axis() * error_quaternion_angle_axis.angle();
+
+
   // define orientation error clipping limit
   const double orientation_delta_lim = delta_lim * 3.0;
-  // clip the orientation error
-  clipVectorMagnitude(error_left.tail(3), orientation_delta_lim);
+  // calculate the magnitude of the orientation error
+  double orientation_error_magnitude = error_left.tail(3).norm();
+  if (orientation_error_magnitude > orientation_delta_lim) {
+    // scale the orientation error to the orientation_delta_lim
+    error_left.tail(3) *= (orientation_delta_lim / orientation_error_magnitude);
+  }
 
   // compute control
   // allocate variables
@@ -534,6 +539,17 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   Eigen::Affine3d transform_left(Eigen::Matrix4d::Map(robot_state_left.O_T_EE.data()));
   Eigen::Map<Eigen::Matrix<double, 7, 1>> dq_left(robot_state_left.dq.data());
   Eigen::Vector3d position_left(transform_left.translation());
+  // compute error to desired pose
+  // position error
+  Eigen::Matrix<double, 6, 1> error_right;
+  error_right.head(3) << position - right_arm_data.position_d_;
+
+  // calculate the magnitude of the position error
+  double position_error_magnitude = error_right.head(3).norm();
+  if (position_error_magnitude > delta_lim){
+    // scale the position error to the delta_lim
+    error_right.head(3) *= (delta_lim / position_error_magnitude);
+
 
   geometry_msgs::PoseStamped msg_right;
   msg_right.pose.position.x=position[0];
@@ -569,20 +585,17 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   force_torque_msg.wrench.torque.z=right_arm_data.force_torque[5];
   pub_force_torque_right.publish(force_torque_msg);
 
-  // compute error to desired pose
-  // position error
-  Eigen::Matrix<double, 6, 1> error_right;
-  error_right.head(3) << position - right_arm_data.position_d_;
-  // clip the position error
-  clipVectorMagnitude(error_right.head(3), delta_lim);
-
-  // relative position error
   Eigen::Matrix<double, 6, 1> error_relative;
   error_relative.head(3) << position - position_left;
   error_relative.tail(3).setZero();
   error_relative.head(3)<< error_relative.head(3) -right_arm_data.position_d_relative_;
-  // clip the relative position error
-  clipVectorMagnitude(error_relative.head(3), delta_lim);
+
+  // calculate the magnitude of the relative position error
+  double relative_error_magnitude = error_relative.head(3).norm();
+  if (relative_error_magnitude > delta_lim){
+    // scale the relative position error to the delta_lim
+    error_relative.head(3) *= (delta_lim / relative_error_magnitude);
+  }
   
   // orientation error
   if (right_arm_data.orientation_d_.coeffs().dot(orientation.coeffs()) < 0.0) {
@@ -594,11 +607,15 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   Eigen::AngleAxisd error_quaternion_angle_axis(error_quaternion);
   // compute "orientation error"
   error_right.tail(3) << error_quaternion_angle_axis.axis() * error_quaternion_angle_axis.angle();
+
   // define orientation error clipping limit
   const double orientation_delta_lim = delta_lim * 3.0;
-  // clip the orientation error
-  clipVectorMagnitude(error_right.tail(3), orientation_delta_lim)
-  
+  // calculate the magnitude of the orientation error
+  double orientation_error_magnitude = error_right.tail(3).norm();
+  if (orientation_error_magnitude > orientation_delta_lim) {
+    // scale the orientation error to the orientation_delta_lim
+    error_right.tail(3) *= (orientation_delta_lim / orientation_error_magnitude);
+  }
 
   // compute control
   // allocate variables

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -24,7 +24,7 @@
 namespace franka_bimanual_controllers {
 
 template <typename Derived>
-void clipVectorMagnitude(Eigen::MatrixBase<Derived>& vec, const double limit) {
+void clipVectorMagnitude(Eigen::Ref<Derived> vec, const double limit) {
     const double magnitude = vec.norm();
     // Only scale the vector if its magnitude is non-zero and exceeds the limit.
     if (magnitude > limit && magnitude > 0) {
@@ -597,7 +597,7 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   // define orientation error clipping limit
   const double orientation_delta_lim = delta_lim * 3.0;
   // clip the orientation error
-  clipVectorMagnitude(error_right.tail(3), orientation_delta_lim)
+  clipVectorMagnitude(error_right.tail(3), orientation_delta_lim);
   
 
   // compute control

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -278,7 +278,7 @@ void BiManualCartesianImpedanceControl::update(const ros::Time& time,
     right_needs_recovery_ = true;
   }
   
-  if (left_needs_recovery && right_needs_recovery) {
+  if (left_needs_recovery_ && right_needs_recovery_) {
     ROS_INFO("E-Stop cycle detected. Triggering automatic error recovery.");
     franka_msgs::ErrorRecoveryActionGoal goal_msg;
     pub_error_recovery_.publish(goal_msg);

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -246,11 +246,6 @@ void BiManualCartesianImpedanceControl::update(const ros::Time& time,
         }
       }
     }
- 
-  // if (!is_safe_.load()) { // atomic read
-  //    // Throw an error
-  //    throw std::runtime_error("Controller is not safe. Exiting update loop.");
-  //  }
 
   if (!is_safe_.load() && controller_state_ == controller_interface::ControllerBase::ControllerState::RUNNING) {
         controller_state_ = controller_interface::ControllerBase::ControllerState::STOPPED;
@@ -315,6 +310,7 @@ void BiManualCartesianImpedanceControl::update(const ros::Time& time,
       }
       break;
     case controller_interface::ControllerBase::ControllerState::RUNNING:
+      break;
     case controller_interface::ControllerBase::ControllerState::STOPPED:
       break;
   }

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -549,6 +549,7 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   if (position_error_magnitude > delta_lim){
     // scale the position error to the delta_lim
     error_right.head(3) *= (delta_lim / position_error_magnitude);
+  }
 
 
   geometry_msgs::PoseStamped msg_right;

--- a/src/bimanual_cartesian_impedance_controller.cpp
+++ b/src/bimanual_cartesian_impedance_controller.cpp
@@ -307,6 +307,9 @@ void BiManualCartesianImpedanceControl::updateArmLeft() {
   auto& right_arm_data = arms_data_.at(right_arm_id_);
   franka::RobotState robot_state_left = left_arm_data.state_handle_->getRobotState();
 
+  //JUST FOR DEBUGGING
+  ROS_INFO_THROTTLE(1.0, "Current left arm mode: %d", static_cast<int>(robot_state_left.robot_mode));
+
   if (robot_state_left.robot_mode == franka::RobotMode::kIdle) {
     if (!left_arm_in_error_) {
       ROS_WARN("Left arm entered Idle mode. Triggering automatic error recovery...");
@@ -486,6 +489,9 @@ void BiManualCartesianImpedanceControl::updateArmRight() {
   auto& right_arm_data = arms_data_.at(right_arm_id_);
   // get state variables
   franka::RobotState robot_state_right = right_arm_data.state_handle_->getRobotState();
+
+  //JUST FOR DEBUGGING
+  ROS_INFO_THROTTLE(1.0, "Current left arm mode: %d", static_cast<int>(robot_state_left.robot_mode));
 
   if (robot_state_right.robot_mode == franka::RobotMode::kIdle) {
     if (!right_arm_in_error_) {


### PR DESCRIPTION
<!-- How to create a pull request (PR): -->
<!-- 1. Name the PR semantically: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716 -->
<!-- 2. Assign the PR to you or any other developer that is contributing or contributed to it. -->
<!-- 3. If the PR is not ready for review yet, mark it as draft. -->
<!-- 4. Once the PR is ready for review and ALL tests are passing on CI/CD: -->
<!--    1. Fill this PR template. You can also do this step before, on the fly, as you do the changes. -->
<!--    2. Mark it as "Ready for review". -->
<!--    3. Set 1-3 reviewers. Select the reviewer depending on the type of change: -->
<!--       - Robotics or CI/CD feature: Ben. -->
<!--       - GUI feature: Victor and Ben. -->
<!--       - AI feature: Victor. -->
<!--       - Any other change: Ben. -->
<!--       Additionally, you can also add more people who you think should have a look at the changes. -->
<!-- 5. Once at least 1 reviewer has approved the PR: -->
<!--    1. You or the reviewer can "Squash and merge". -->
<!--    2. Delete the branch. -->

## ✍️ Changes
- fixes robot not moving after estops are released by adding an automatic error recovery when the robot  goes from [kUserStopped](https://docs.ros.org/en/kinetic/api/libfranka/html/namespacefranka.html#adfe059ae23ebbad59e421edaa879651a) to idle ([kIdle](https://docs.ros.org/en/kinetic/api/libfranka/html/namespacefranka.html#adfe059ae23ebbad59e421edaa879651a)) mode
- Introduces a controller-level state machine (RUNNING, STOPPED, WAITING) 
- Implements a new collision-handling routine where the controller freezes its last desired pose instead of throwing an error
- Refactors automatic error recovery to trigger specifically on an E-stop cycle (transition from kUserStopped to kIdle), whether a collision occurred or not
- Adds a "soft start" mechanism post-recovery, where the controller adopts the robot's current pose as its new goal to prevent unexpected movements after being manually repositioned
- publishes the franka robot mode to ros topic `panda_left_robot_mode` and `panda_right_robot_mode`, so we can subscribe to it on the high level ros2 controller and decouple



## 🤔 Why
After the estops are released, the robot should not be in kIdle mode, it should be in kMove mode, otherwise it will not execute commands from the bimanual controller. This fix sends an action goal (`franka_msgs::ErrorRecoveryActionGoal`) to `/panda_dual/error_recovery/goal`, which triggers an automatic error recovery that sets the robot mode to kMove. Also before, a self-collision event (detected via heartbeat loss) would cause the controller to crash, requiring a full restart. This PR makes the controller recover from e-stops cycles and can survive collision events by freezing the robot and waiting for operator to recycle the estops

## 🤓 Explanation
- The PR from [auto-recover from error #279](https://github.com/frankarobotics/franka_ros/pull/279) actually removed automatic error recovery in this exact case because a reviewer of the PR assumed idle mode means no errors exist, which was not the case for us.
- Upon loss of the collision-detection heartbeat, the state transitions to STOPPED. In this state, the controller uses a "frozen" target pose from before the event and ignores new teleoperation commands.
- An automatic error recovery is triggered whenever an E-stop is released (kUserStopped -> kIdle). This check runs universally, outside the state machine, to handle all E-stop scenarios.
- If recovery is triggered from the STOPPED state (estop recycle), the controller transitions to WAITING.
- Upon successful recovery, the controller transitions back to RUNNING and sets its desired pose to the robot's current actual pose. This prevents the robot from trying to move back to a previous position after being handled manually

## 🔧 Integration Testing
- [x] test recycling of estops (does it recover)
- [x] test collision (should freeze until estops are recycled)
- [x] test collision and then manually moving the arms to a non collision position and recycling (shouldnt jump back to collision pose)
- [x] check if in ros2 level the topic `panda_left_robot_mode` and `panda_right_robot_mode` exist and echo them

## 🔮 Future Work
decouple in the arm_teleop_node


<!-- Source: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->